### PR TITLE
Changed eZ80 Heaven link

### DIFF
--- a/pages/external/externallinks.html
+++ b/pages/external/externallinks.html
@@ -9,7 +9,7 @@ permalink: /links/
 <a href="http://www.zilog.com/docs/um0077.pdf">http://www.zilog.com/docs/um0077.pdf</a>
 <p>Official eZ80 CPU documentation</p>
 
-<a href="http://hactarce.github.io/ez80-heaven/">http://hactarce.github.io/ez80-heaven/</a>
+<a href="http://ez80.github.io/">http://ez80.github.io</a>
 <p>Tutorials and information about eZ80 assembly (WIP)</p>
 
 <a href="http://mdfs.net/Docs/Comp/eZ80/OpList">http://mdfs.net/Docs/Comp/eZ80/OpList</a>


### PR DESCRIPTION
The site is being moved to http://ez80.github.io/ and KingInfinity is collaborating on it with me.
